### PR TITLE
Add support for coffeescript

### DIFF
--- a/lib/ape.js
+++ b/lib/ape.js
@@ -186,5 +186,6 @@ var languages = {
     '.js': { name: 'javascript', comment: /^\s*\/\/\s?/, start: /^\s*\/\*\s?/, end: /\*\/\s*$/ },
     '.py': { name: 'python', comment: /^\s*#\s?/, start: /^\s*\"\"\"\s?/, end: /\"\"\"\s*$/ },
     '.rb': { name: 'ruby', comment: /^\s*#\s?/, start: /^\s*\=begin\s?/, end: /\=end\s*$/ },
-    '.lua': { name: 'lua', comment: /^\s*--\s?/, start: /^\s*--\[\[\s?/, end: /--\]\]\s*$/ }
+    '.lua': { name: 'lua', comment: /^\s*--\s?/, start: /^\s*--\[\[\s?/, end: /--\]\]\s*$/ },
+    '.coffee': { name: 'coffeescript', comment: /^\s*#(?!##)\s?/, start: /^\s*###\s?/, end: /###\s*$/ }
 };


### PR DESCRIPTION
had to use a negative lookahead since coffeescript's
single-line comment delimiter (#) is a substring of it's
multi-line comment start delimiter (###).
